### PR TITLE
feat: write 이벤트 활성화 기능 추가

### DIFF
--- a/Channel/Channel.cpp
+++ b/Channel/Channel.cpp
@@ -14,36 +14,48 @@ Channel::~Channel()
 }
 
 // 채널에 들어옴
-void Channel::joinChannel(Client cl) {
-    if (this->m_is_mode_invite) {
+void Channel::joinChannel(Client cl)
+{
+    if (this->m_is_mode_invite)
+    {
         // todo: 초대 여부 확인
     }
-    if (this->m_is_mode_key) {
+    if (this->m_is_mode_key)
+    {
         // todo: 비밀번호 입력 확인
     }
-    if (this->m_is_mode_limit) {
-        if (this->m_user_count == this->m_limit_count) {
+    if (this->m_is_mode_limit)
+    {
+        if (this->m_user_count == this->m_limit_count)
+        {
             // todo: error reply 설정
         }
-    } 
+    }
 
     this->m_user_count++;
-    this->m_normals.push_back(cl);
+    cl.setCurChannel(this->getName()); // 클라이언트의 현재 채널이름 설정
+    this->m_normals.push_back(cl);     // 목록에 넣기
 }
 
 // 채널 나가기
-void Channel::partChannel(Client cl) {
+void Channel::partChannel(Client cl)
+{
     this->m_user_count--;
-    for (std::size_t i = 0; i < this->m_operators.size(); i++) {
-        if (this->m_operators[i].getNick() == cl.getNick()) {
+    for (std::size_t i = 0; i < this->m_operators.size(); i++)
+    {
+        if (this->m_operators[i].getNick() == cl.getNick())
+        {
             this->m_operators.erase(this->m_operators.begin() + i);
-            return ;
+            return;
         }
     }
-    for (std::size_t i = 0; i < this->m_normals.size(); i++) {
-        if (this->m_normals[i].getNick() == cl.getNick()) {
+    for (std::size_t i = 0; i < this->m_normals.size(); i++)
+    {
+        if (this->m_normals[i].getNick() == cl.getNick())
+        {
+            cl.setCurChannel(NULL); // 클라이언트의 현재 채널이름도 NULL로
             this->m_normals.erase(this->m_normals.begin() + i);
-            return ;
+            return;
         }
     }
 }

--- a/Channel/Channel.hpp
+++ b/Channel/Channel.hpp
@@ -12,10 +12,10 @@ class Client; // 전방 선언
 class Channel
 {
   private:
-    std::string m_name;
+    std::string m_name;				// 현재 채널의 이름
     time_t m_cretaed;
-    std::vector<Client> m_operators;
-    std::vector<Client> m_normals;
+    std::vector<Client> m_operators; // op인 유저들의 목록
+    std::vector<Client> m_normals;   // 채팅방 속 모든 유저들의 목록
     std::vector<std::string> m_bans;
     std::string m_topic;
     std::string m_key;

--- a/Client/Client.cpp
+++ b/Client/Client.cpp
@@ -14,11 +14,16 @@ Client &Client::operator=(const Client &other)
     if (this != &other)
     {
         m_socket_fd = other.m_socket_fd;
+        m_recv_data = other.m_recv_data;
+        m_send_msg = other.m_send_msg;
         m_nick = other.m_nick;
         m_username = other.m_username;
+        m_password = other.m_password;
         m_cur_channel = other.m_cur_channel;
         m_flag_connect = other.m_flag_connect;
         m_is_op = other.m_is_op;
+        m_is_registered = other.m_is_registered;
+        m_write_types = other.m_write_types;
         // 추가된 멤버 변수가 있다면 여기에 복사 로직을 추가
     }
     return *this;
@@ -60,14 +65,19 @@ void Client::setSendMsg(std::string msg)
     m_send_msg = msg;
 }
 
-void Client::setWritable(const bool boolean)
+void Client::setWriteTypes(const writeEvent type)
 {
-    m_is_writable = boolean;
+    m_write_types = type;
 }
 
 void Client::setRegistered(bool tf)
 {
     m_is_registered = tf;
+}
+
+void Client::setCurChannel(const std::string channel)
+{
+    m_cur_channel = channel;
 }
 
 // Getter 함수들
@@ -91,9 +101,14 @@ std::string Client::getSendMsg()
     return m_send_msg;
 }
 
-bool Client::getWritable()
+std::string Client::getCurChannel()
 {
-    return m_is_writable;
+    return m_cur_channel;
+}
+
+writeEvent Client::getWriteTypes()
+{
+    return m_write_types;
 }
 
 bool Client::getRegisterd()

--- a/Client/Client.cpp
+++ b/Client/Client.cpp
@@ -130,11 +130,12 @@ void Client::startListen(int serv_sock)
     fcntl(m_socket_fd, F_SETFL, O_NONBLOCK);
 }
 
-void Client::startParseMessage()
+void Client::startParseMessage(Server &serv)
 {
     // message 클래스의 객체 넣기
     Message msg(m_recv_data);
     // 테스트용 임시 서버객체
+
     Server a;
     a.setName("test");
     a.setCreated(time(NULL));

--- a/Client/Client.hpp
+++ b/Client/Client.hpp
@@ -70,7 +70,7 @@ class Client
     void setRegistered(bool tf);
 
     void startListen(int serv_sock);
-    void startParseMessage();
+    void startParseMessage(Server &serv);
     void startResponse(std::map<int, Channel> &channels);
     void startSend();
 };

--- a/Client/Client.hpp
+++ b/Client/Client.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include "../Channel/Channel.hpp"
+#include "../Message/Command.hpp"
 #include "../Message/Message.hpp"
 #include "../Server/Server.hpp"
-#include "../Message/Command.hpp"
 
 #include <arpa/inet.h>
 #include <fcntl.h>
@@ -13,6 +13,14 @@
 #include <sys/event.h>
 #include <sys/socket.h>
 #include <unistd.h>
+
+enum writeEvent
+{
+    NONE,
+    MYSELF,
+    EVERYBUTME,
+    EVERYONE
+};
 
 class Channel; // 전방 선언
 class Message;
@@ -27,12 +35,11 @@ class Client
     std::string m_nick;        // 닉네임
     std::string m_username;    // 유저네임
     std::string m_password;    // 패스워드
-    std::string m_cur_channel; // 현재 채널명
+    std::string m_cur_channel; // 현재 채널
     int m_flag_connect;        // 연결 여부
     bool m_is_op;              // op(방장) 여부
-    bool m_is_writable;        // 소켓의 write 이벤트 활성화 여부
-
     bool m_is_registered;      // 서버 등록 여부
+    writeEvent m_write_types;  // write 이벤트의 종류
 
   public:
     Client();
@@ -46,8 +53,8 @@ class Client
     std::string getRecvData();
     std::string getSendMsg();
     std::string getUser();
-    bool getWritable();
-
+    std::string getCurChannel();
+    writeEvent getWriteTypes();
     bool getRegisterd();
 
     // Setter 함수들
@@ -55,16 +62,15 @@ class Client
     void setNick(const std::string &nick);
     void setUsername(const std::string &username);
     void setRecvData(const char *data);
-    void setWritable(const bool boolean);
+    void setWriteTypes(const writeEvent type);
+    void setCurChannel(const std::string channel);
+
+    void setSendMsg(std::string msg);
+    void addSendMsg(std::string msg);
+    void setRegistered(bool tf);
 
     void startListen(int serv_sock);
     void startParseMessage();
     void startResponse(std::map<int, Channel> &channels);
     void startSend();
-
-    void setSendMsg(std::string msg);
-    void setRegistered(bool tf);
-
-
-    void addSendMsg(std::string msg);
 };

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -192,10 +192,7 @@ void Server::handleRecv(int fd)
     std::cout << "================ start ==========\n";
     std::cout << "clnt: " << buffer << std::endl;
     std::cout << "read success" << std::endl;
-    clnt.startParseMessage();
-
-    // 추후 추가 : 데이터에 대한 응답 생성
-    // clnt.startResponse(m_channels);
+    clnt.startParseMessage(*this);
 
     // 클라이언트 소켓의 write 이벤트 활성화
     if (clnt.getWriteTypes() == MYSELF)

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -17,6 +17,11 @@ Server &Server::operator=(const Server &other)
         m_portnum = other.m_portnum;
         m_serv_sock = other.m_serv_sock;
         m_kqueue = other.m_kqueue;
+        m_clients = other.m_clients;
+        m_channels = other.m_channels;
+        m_change_vec = other.m_change_vec;
+        m_name = other.m_name;
+        m_created = other.m_created;
     }
     return *this;
 }
@@ -162,7 +167,7 @@ void Server::handleConnect()
 
     // 클라이언트 소켓의 write 이벤트 비활성화
     disableWriteEvent(clnt.getsockfd());
-    clnt.setWritable(false);
+    clnt.setWriteTypes(NONE);
 
     // 클라이언트의 map에 등록
     m_clients.insert(std::make_pair(clnt.getsockfd(), clnt));
@@ -193,9 +198,10 @@ void Server::handleRecv(int fd)
     // clnt.startResponse(m_channels);
 
     // 클라이언트 소켓의 write 이벤트 활성화
-    // if (clnt.getWritable() == true)
-    // 	enableWriteEvent(clnt_sock);
-    enableWriteEvent(clnt_sock);
+    if (clnt.getWriteTypes() == MYSELF)
+        enableWriteEvent(clnt_sock);
+    else if (clnt.getWriteTypes() == EVERYBUTME || clnt.getWriteTypes() == EVERYONE)
+        enableMultipleWrite(clnt);
 }
 
 void Server::handleSend(int fd)
@@ -210,7 +216,7 @@ void Server::handleSend(int fd)
 
     // 클라이언트 소켓의 write 이벤트 비활성화
     disableWriteEvent(clnt.getsockfd());
-    clnt.setWritable(false);
+    clnt.setWriteTypes(NONE);
 }
 
 void Server::handleDisconnect()

--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -188,7 +188,7 @@ void Server::handleRecv(int fd)
     buffer[bytes_read] = '\0';
     clnt.setRecvData(buffer);
 
-    // 데이터 체크 및 파싱
+    // 데이터 파싱
     std::cout << "================ start ==========\n";
     std::cout << "clnt: " << buffer << std::endl;
     std::cout << "read success" << std::endl;

--- a/Server/Server.hpp
+++ b/Server/Server.hpp
@@ -32,8 +32,8 @@ class Server
     int m_serv_sock;
     int m_kqueue;
     std::map<int, Client> m_clients;         // 클라이언트 목록
-    std::map<int, Channel> m_channels;       // 채널 목록
-    std::vector<struct kevent> m_change_vec; // 이벤트 목록
+    std::map<std::string, Channel> m_channels; // 채널 목록
+    std::vector<struct kevent> m_change_vec;  // 이벤트 목록
 
     std::string m_name; // 서버 이름
     time_t m_created;   // 생성시간
@@ -64,6 +64,7 @@ class Server
     void addWriteEvent(int sockfd);
     void disableWriteEvent(int sockfd);
     void enableWriteEvent(int sockfd);
+    void enableMultipleWrite(Client &clnt);
 
     std::string getName();
     time_t getCreated();

--- a/Server/utils.cpp
+++ b/Server/utils.cpp
@@ -31,3 +31,22 @@ void Server::enableWriteEvent(int sockfd)
     if (kevent(m_kqueue, &write_event, 1, NULL, 0, NULL) == -1)
         throw std::runtime_error("kevent() of enableWriteEvent was wrong..");
 }
+
+void Server::enableMultipleWrite(Client &clnt)
+{
+    writeEvent event_type = clnt.getWriteTypes();
+    std::string ch_name = clnt.getCurChannel();
+
+    // 채널 찾기
+    Channel ch = m_channels.at(ch_name);
+    std::vector<Client> normal = ch.getNormals();
+    std::vector<Client>::iterator iter;
+
+    // 일단 해당채널 속 모든 클라이언트의 write 활성화
+    for (iter = normal.begin(); iter != normal.end(); iter++)
+        enableWriteEvent(iter->getsockfd());
+
+    // 필요 시, 파라미터 clnt의 write만 해제
+    if (event_type == EVERYBUTME)
+        disableWriteEvent(clnt.getsockfd());
+}


### PR DESCRIPTION
* 기존: 클라이언트 소켓이 read를 한 후 자기 자신의 write 이벤트를 활성화할지 말지를 결정
* 신규: 기준을 '자기 자신'에서 '자기 자신의 채널'로 확장

분기를 나누면 다음과 같습니다.
```
<Write 이벤트를 활성화 할 필요가 있다.>
1. 자기 자신만 활성화한다.
2. 자기 자신만 빼고 나머지를 전부 활성화한다.
3. 전부 활성화한다.

<Write 이벤트를 활성화 할 필요가 없다.>
1. 아무것도 안함.
```

- 서버 클래스에 새로운 메소드 추가.
- 클라이언트 클래스에 새로운 변수 및 메소드 추가.
- 채널 클래스: 클라이언트가 채널에서 들어오고 나갈 때 각 클라이언트의 현재 채널명 조정하는 기능 추가.