### PR TITLE
[refactor] Command, Message - Command 관리 방식 변경

### DIFF
--- a/Message/Message.cpp
+++ b/Message/Message.cpp
@@ -45,17 +45,17 @@ bool Message::crlfCheck()
  */
 void Message::execute(Server &server, Client &client)
 {
-    std::vector<Command *>::const_iterator it;
+    std::vector<Command>::iterator it;
 
     for (it = this->m_cmds.begin(); it != this->m_cmds.end(); it++)
     {
         if (!client.getRegisterd())
         {
-            registerExecute(server, client, *it);
+            registerExecute(server, client, &(*it));
         }
         else
         {
-            commandExecute(server, client, *it);
+            commandExecute(server, client, &(*it));
         }
     }
 }
@@ -66,7 +66,7 @@ void Message::execute(Server &server, Client &client)
 static int findCommands(const std::string &cmd)
 {
     const std::string commands[COMMAND_SIZE] = {"CAP",  "PASS", "NICK",  "USER",   "PING",    "QUIT", "JOIN",
-                                      "PART", "MODE", "TOPIC", "INVITE", "PRIVMSG", "WHO",  "KICK"};
+                                                "PART", "MODE", "TOPIC", "INVITE", "PRIVMSG", "WHO",  "KICK"};
 
     for (int i = 0; i < COMMAND_SIZE; i++)
     {
@@ -186,7 +186,7 @@ const std::string &Message::getOrigin() const
     return this->m_origin;
 }
 
-const std::vector<Command *> &Message::getCmds() const
+const std::vector<Command> &Message::getCmds() const
 {
     return this->m_cmds;
 }
@@ -197,7 +197,7 @@ void Message::setOrigin(std::string &origin)
     this->m_origin = origin;
 }
 
-void Message::setCmds(std::vector<Command *> &cmds)
+void Message::setCmds(std::vector<Command> &cmds)
 {
     this->m_cmds = cmds;
 }

--- a/Message/Message.hpp
+++ b/Message/Message.hpp
@@ -43,7 +43,7 @@ class Message
 {
   private:
     std::string m_origin;
-    std::vector<Command *> m_cmds;
+    std::vector<Command> m_cmds;
     Message();
 
   public:
@@ -54,11 +54,11 @@ class Message
 
     /* getter */
     const std::string &getOrigin() const;
-    const std::vector<Command *> &getCmds() const;
+    const std::vector<Command> &getCmds() const;
 
     /* setter */
     void setOrigin(std::string &origin);
-    void setCmds(std::vector<Command *> &cmds);
+    void setCmds(std::vector<Command> &cmds);
 
     bool crlfCheck();
     void display();

--- a/Message/parsing.cpp
+++ b/Message/parsing.cpp
@@ -17,10 +17,10 @@ void Message::parsingOrigin()
             split.pop_back();
         }
 
-        Command *cmd = new Command();
+        Command cmd;
 
         // space 기준으로 스플릿
-        parsingSpace(split, cmd);
+        parsingSpace(split, &cmd);
         this->m_cmds.push_back(cmd);
     }
 }


### PR DESCRIPTION
### 설명
---
- Message 클래스에서 Command 객체 포인터 배열을 멤버변수로 가지고 있어습니다.
- 이 때, Command 객체를 new로 할당한 후 포인터만 배열에 넣는 식으로 관리했었는데
- 이 부분을 객체를 벡터에 직접 넣어서 복사생성된 객체를 가지는 방식으로 변경해서
- 마지막에 delete 할 필요없이 사용할 수 있게 바꿨습니다.