### PR TITLE
fix: Message 메서드 수정

### DIFF
--- a/Message/join.cpp
+++ b/Message/join.cpp
@@ -66,6 +66,11 @@ void Message::joinExecute(Server &server, Client &client, Command *cmd)
     for (size_t i = 0; i < channelNames.size(); ++i)
     {
         std::string channelName = channelNames[i];
+        if (channelName[0] != '#' && channelName[0] != '&')
+        {
+            client.addSendMsg(Response::ERR_BADCHANMASK_476(server, client, channelName));
+            return;
+        }
         std::string key = i < keys.size() ? keys[i] : "";
 
         Channel *channel = server.findChannel(channelName);

--- a/Message/part.cpp
+++ b/Message/part.cpp
@@ -23,10 +23,10 @@ void Message::partExecute(Server &server, Client &client, Command *cmd)
     std::vector<std::string> channels;
     std::string reason;
 
-    cmd->display();
     if (cmd->getParams().empty()) // /part     /part #channel
     {
         client.addSendMsg(Response::ERR_NEEDMOREPARAMS_461(server, client, "PART"));
+        return;
     }
     parseChannelAndReason(cmd->getParams(), channels, reason);
 
@@ -50,6 +50,7 @@ void Message::partExecute(Server &server, Client &client, Command *cmd)
             channel->addSendMsgAll(server, client.getNick(), "PART " + channelName, reason);
         else
             channel->addSendMsgAll(server, client.getNick(), "PART", channelName);
+        std::cout << "partExecute in" << std::endl;
         channel->partChannel(client);
     }
 }

--- a/Message/pass.cpp
+++ b/Message/pass.cpp
@@ -13,6 +13,10 @@ void Message::registerPassExecute(Server &server, Client &client, Command *cmd)
         client.addSendMsg(Response::ERR_NEEDMOREPARAMS_461(server, client, cmd->getCommand()));
         return;
     }
+    if (server.getPassword() != cmd->getParams()[0])
+    {
+        client.addSendMsg(Response::ERR_PASSWDMISMATCH_464(server, client));
+    }
     if (server.getPassword() == cmd->getParams()[0])
     {
         client.setRegisterFlags(PASS_REG, true);

--- a/Response/Response.cpp
+++ b/Response/Response.cpp
@@ -23,6 +23,11 @@ std::string Response::ERR_NEEDMOREPARAMS_461(Server &server, Client &client, con
     return GENERATE(server.getName(), "461", client.getNick() + " " + command + " :Not enough parameters");
 }
 
+std::string Response::ERR_BADCHANMASK_476(Server &server, Client &client, const std::string &ch_name)
+{
+    return GENERATE(server.getName(), "476", client.getNick() + " " + ch_name + " :Bad Channel Mask");
+}
+
 // PASS USER
 std::string Response::ERR_ALREADYREGISTERED_462(Server &server, Client &client)
 {
@@ -32,6 +37,11 @@ std::string Response::ERR_ALREADYREGISTERED_462(Server &server, Client &client)
 std::string Response::RPL_USERHOST_302(Server &server, Client &client)
 {
     return GENERATE(server.getName(), "302", client.getNick() + " :");
+}
+
+std::string Response::ERR_PASSWDMISMATCH_464(Server &server, Client &client)
+{
+    return GENERATE(server.getName(), "464", client.getNick() + " :Password incorrect");
 }
 
 // NICK

--- a/Response/Response.hpp
+++ b/Response/Response.hpp
@@ -37,6 +37,7 @@ class Response
     // PASS, USER
     static std::string ERR_ALREADYREGISTERED_462(Server &server, Client &client);
     static std::string RPL_USERHOST_302(Server &server, Client &client);
+	static std::string ERR_PASSWDMISMATCH_464(Server &server, Client &client);
 
     // NICK
     static std::string ERR_NONICKNAMEGIVEN_431(Server &server, Client &client);
@@ -52,6 +53,7 @@ class Response
     // :irc.local 353 a = #a :@a
     // :irc.local 366 a #a :End of /NAMES list.
     static std::string RPL_TOPIC_332(Server &server, Client &client, Channel &channel);
+	static std::string ERR_BADCHANMASK_476(Server &server, Client &client, const std::string &ch_name);
 
     static std::string ERR_INVITEONLYCHAN_473(Server &server, Client &client, Channel &channel);
     static std::string ERR_BADCHANNELKEY_475(Server &server, Client &client, Channel &channel);


### PR DESCRIPTION
- part 메서드에서 params가 empty일때 에러메시지 출력 후 return; 추가
- join 메서드에서 채널 이름이 '#' || '&' 로 시작하지 않을 경우 에러 메시지 추가
- pass 메서드에서 입력한 비밀번호가 일치하지 않을 경우 에러 메시지 추가