### PR TITLE
feat: Server name 지정 및 disconnect(QUIT 포괄) 업데이트

### DIFF
--- a/Client/Client.cpp
+++ b/Client/Client.cpp
@@ -1,6 +1,6 @@
 #include "Client.hpp"
 
-Client::Client() : m_is_registered(false)
+Client::Client() : m_is_registered(false), m_leave_msg("null")
 {
     m_is_register_flags[PASS_REG] = false;
     m_is_register_flags[NICK_REG] = false;
@@ -31,6 +31,7 @@ Client &Client::operator=(const Client &other)
         m_is_register_flags[1] = other.m_is_register_flags[1];
         m_is_register_flags[2] = other.m_is_register_flags[2];
         m_write_types = other.m_write_types;
+        m_leave_msg = other.m_leave_msg;
         // 추가된 멤버 변수가 있다면 여기에 복사 로직을 추가
     }
     return *this;
@@ -167,6 +168,11 @@ bool *Client::getIsRegisterFlags()
     return m_is_register_flags;
 }
 
+std::string Client::getLeaveMsg()
+{
+    return m_leave_msg;
+}
+
 void Client::startListen(int serv_sock)
 {
     struct sockaddr_in clnt_adr;
@@ -215,4 +221,9 @@ void Client::startSend()
 void Client::addSendMsg(std::string msg)
 {
     this->m_send_msg += msg;
+}
+
+void Client::setLeaveMsg(std::string msg)
+{
+    this->m_leave_msg = msg;
 }

--- a/Client/Client.hpp
+++ b/Client/Client.hpp
@@ -17,9 +17,9 @@
 
 enum eRegister
 {
-  PASS_REG,
-  NICK_REG,
-  USER_REG
+    PASS_REG,
+    NICK_REG,
+    USER_REG
 };
 
 enum writeEvent
@@ -50,6 +50,7 @@ class Client
     int m_flag_connect;        // 연결 여부
     bool m_is_registered;      // 서버 등록 여부
     writeEvent m_write_types;  // write 이벤트의 종류
+    std::string m_leave_msg;   // 떠나는 이유 관련 메시지
 
     bool m_is_register_flags[3]; // PASS, NICK, USER 등록 플래그
 
@@ -72,6 +73,7 @@ class Client
     std::string getRealname();
     bool getRegisterd();
     bool *getIsRegisterFlags();
+    std::string getLeaveMsg();
 
     // Setter 함수들
     void setRecvFd(const int number);
@@ -88,6 +90,7 @@ class Client
     void addSendMsg(std::string msg);
     void setRegistered(bool tf);
     void setRegisterFlags(int i, bool tf);
+    void setLeaveMsg(std::string msg);
 
     void startListen(int serv_sock);
     void startParseMessage(Server &serv);

--- a/Message/quit.cpp
+++ b/Message/quit.cpp
@@ -2,26 +2,9 @@
 
 void Message::quitExecute(Server &server, Client &client, Command *cmd)
 {
-    std::string reason = " :leaving";	// "떠나는 이유" 초기화
-    if (!cmd->getParams().empty())		// "떠나는 이유" 필요 시 변경
-        reason = cmd->getParams()[0]; 
-
-	// 채널 목록을 돌면서 각 채널에서 "quit"하는 클라이언트를 삭제
-    std::map<std::string, Channel *>::iterator it;
-    for (it = server.getChannels().begin(); it != server.getChannels().end(); ++it)
-    {
-        Channel *channel = it->second;
-        if (channel->isMember(client))
-        {
-            const std::vector<Client *> members = channel->getNormals();
-            for (size_t i = 0; i < members.size(); ++i)
-            {
-                if (members[i]->getNick() != client.getNick())
-                {
-                    // 이때 채널에 있는 모든 유저들에게 메시지를 보내야 한다.
-                }
-            }
-            channel->partChannel(client);
-        }
-    }
+    std::string reason = " :leaving"; // "떠나는 이유" 초기화
+    if (!cmd->getParams().empty())    // "떠나는 이유" 필요 시 변경
+        reason = cmd->getParams()[0];
+    client.setLeaveMsg(reason);
+    (void)server;
 }

--- a/Server/Server.hpp
+++ b/Server/Server.hpp
@@ -81,5 +81,6 @@ class Server
     Channel *findChannel(const std::string &ch_name);
     Client *findClient(const std::string &client_name);
     bool searchNick(int fd, const std::string &nick);
-	void delEmptyChannel();
+    void delEmptyChannel();
+    void delClientFromChannel(Client &clnt);
 };


### PR DESCRIPTION
## 주요 변경점
1. Server의 이름 지정 : `Bytetalkers`로 지었습니다. (맘에 안드시면 바꾸겠습니다 ^__^)
2. 클라이언트 연결 종료 시

### 기존
```
read 이벤트
- quit에서 메시지 지정
- 채널에서 해당 클라이언트 지우기
- 다른 클라이언트에게 보내기
disconnect 이벤트
- 소켓 연결 끊기만 한다.

-> 이렇게 하니 클라이언트가 ctrl + c를 하면 다른 클라이언트에게 메시지가 보내지지 않는다.
```

### 변경
```
read 이벤트 -> quit 메소드
- quit에서 메시지 지정.
disconnect 이벤트
- 채널에서 해당 클라이언트 지우기
- 다른 클라이언트에게 보내기
- 소켓 연결 끊기.

Client 클래스에서 leave_msg 만들어서
- 생성자에서 기본 메시지 = null로 만들기
- read 이벤트에서 leave_msg를 설정.

따라서 CTRL + C 입력 시 보낼 메시지와 정상종료 메시지 구분
```