### PR TITLE
fix: nc, ctrl+c, 1명 남은 상황 해결

### DIFF
--- a/Server/Server.cpp
+++ b/Server/Server.cpp
@@ -231,6 +231,9 @@ void Server::handleDisconnect(int fd)
     // 각 채널에서 나갈 클라이언트 삭제
     delClientFromChannel(clnt);
 
+    // 빈 채널 삭제 (ctrl + c를 위한 로직)
+    delEmptyChannel();
+
     // 클라이언트의 소켓을 닫는다.
     if (close(fd) == -1)
         throw std::runtime_error("close() error");


### PR DESCRIPTION
* nc로 접속, 1명이 1개의 방에 접속
* 이 상황에서 ctrl + c로 접속했을 때의 문제 : 빈 방이 지워지지 않는다.
* 이를 해결하기 위해 로직 추가